### PR TITLE
media-sound/rosegarden: Use https instead of http

### DIFF
--- a/packages/media-sound/rosegarden/rosegarden-16.06.exheres-0
+++ b/packages/media-sound/rosegarden/rosegarden-16.06.exheres-0
@@ -16,7 +16,7 @@ Rosegarden is an easy-to-learn, attractive application that runs on Linux, ideal
 for composers, musicians, music students, and small studio or home recording
 environments.
 "
-HOMEPAGE="http://rosegardenmusic.com"
+HOMEPAGE="https://rosegardenmusic.com"
 
 LICENCES="GPL-2"
 SLOT="0"


### PR DESCRIPTION
***** Overview

Previous HOMEPAGE, <http://rosegardenmusic.com>, redirects to [http[s]://rosegardenmusic.com](https://rosegardenmusic.com).