### PR TITLE
media-sound/beep: Update to 1.4.12

### DIFF
--- a/packages/media-sound/beep/beep-1.4.12.exheres-0
+++ b/packages/media-sound/beep/beep-1.4.12.exheres-0
@@ -1,12 +1,11 @@
 # Copyright 2009 Jonathan Dahan <jedahan@gmail.com>
 # Distributed under the terms of the GNU General Public License v2
+require github [ user=spkr-beep tag=v${PV} ]
 
 SUMMARY="Advanced PC speaker beeper"
 DESCRIPTION="
 beep  allows  the  user  to  control  the  pc-speaker with precision, allowing different sounds to indicate different events.  While it can be run quite happily on the command line, it's intended place of residence is within shell/perl scripts,  notifying  the  user when something interesting occurs.  Of course, it has no notion of what's interesting, but it's real good at that notifying part.
 "
-HOMEPAGE="http://www.johnath.com/beep"
-DOWNLOADS="${HOMEPAGE}/${PNV}.tar.gz"
 
 LICENCES="GPL-2"
 SLOT="0"


### PR DESCRIPTION
Compilation results in error

```
[38;5;241m35;01m===[38;5;241m0m Running ebuild phase killold as root:root...
[38;5;241m35;01m===[38;5;241m0m Starting builtin_killold
[38;5;241m35;01m===[38;5;241m0m Done builtin_killold
[38;5;241m35;01m===[38;5;241m0m Completed ebuild phase killold
[38;5;241m35;01m===[38;5;241m0m Running ebuild phases init saveenv as paludisbuild:paludisbuild...
[38;5;241m35;01m===[38;5;241m0m Starting builtin_init
[38;5;241m35;01m===[38;5;241m0m Done builtin_init
[38;5;241m35;01m===[38;5;241m0m Starting builtin_saveenv
[38;5;241m35;01m===[38;5;241m0m Done builtin_saveenv
[38;5;241m35;01m===[38;5;241m0m Completed ebuild phases init saveenv
--- No need to do anything for setup phase
[38;5;241m35;01m===[38;5;241m0m Running ebuild phases loadenv unpack saveenv as paludisbuild:paludisbuild...
[38;5;241m35;01m===[38;5;241m0m Starting builtin_loadenv
[38;5;241m35;01m===[38;5;241m0m Done builtin_loadenv
[38;5;241m35;01m===[38;5;241m0m Starting src_unpack
>>> Unpacking beep-1.4.12.tar.gz to /var/tmp/paludis/build/media-sound-beep-1.4.12/work
tar zxf /var/cache/paludis/distfiles/beep-1.4.12.tar.gz --no-same-owner
[38;5;241m35;01m===[38;5;241m0m Done src_unpack
[38;5;241m35;01m===[38;5;241m0m Starting builtin_saveenv
[38;5;241m35;01m===[38;5;241m0m Done builtin_saveenv
[38;5;241m35;01m===[38;5;241m0m Completed ebuild phases loadenv unpack saveenv
[38;5;241m35;01m===[38;5;241m0m Running ebuild phases loadenv prepare saveenv as paludisbuild:paludisbuild...
[38;5;241m35;01m===[38;5;241m0m Starting builtin_loadenv
[38;5;241m35;01m===[38;5;241m0m Done builtin_loadenv
[38;5;241m35;01m===[38;5;241m0m Starting src_prepare
[38;5;241m35;01m===[38;5;241m0m Done src_prepare
[38;5;241m35;01m===[38;5;241m0m Starting builtin_saveenv
[38;5;241m35;01m===[38;5;241m0m Done builtin_saveenv
[38;5;241m35;01m===[38;5;241m0m Completed ebuild phases loadenv prepare saveenv
[38;5;241m35;01m===[38;5;241m0m Running ebuild phases loadenv configure saveenv as paludisbuild:paludisbuild...
[38;5;241m35;01m===[38;5;241m0m Starting builtin_loadenv
[38;5;241m35;01m===[38;5;241m0m Done builtin_loadenv
[38;5;241m35;01m===[38;5;241m0m Starting src_configure
[38;5;241m35;01m===[38;5;241m0m Done src_configure
[38;5;241m35;01m===[38;5;241m0m Starting builtin_saveenv
[38;5;241m35;01m===[38;5;241m0m Done builtin_saveenv
[38;5;241m35;01m===[38;5;241m0m Completed ebuild phases loadenv configure saveenv
[38;5;241m35;01m===[38;5;241m0m Running ebuild phases loadenv compile saveenv as paludisbuild:paludisbuild...
[38;5;241m35;01m===[38;5;241m0m Starting builtin_loadenv
[38;5;241m35;01m===[38;5;241m0m Done builtin_loadenv
[38;5;241m35;01m===[38;5;241m0m Starting src_compile
make -j6 CC=x86_64-pc-linux-musl-cc
#=======================================================================
# common_CFLAGS=-O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral
# CFLAGS=-fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj
# CPPFLAGS=-D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS
#=======================================================================
sed -e 's|@PACKAGE_TARNAME@|beep|g' -e 's|@PACKAGE_VERSION@|1.4.12|g' -e 's|@DEFAULT_FREQ@|440|g' -e 's|@DEFAULT_LENGTH@|200|g' -e 's|@DEFAULT_DELAY@|100|g' -e 's|[@]docdir@|/usr/local/share/doc/beep|g' < beep-config.h.in > beep-config.h.new
mv -f beep-config.h.new beep-config.h
x86_64-pc-linux-musl-cc -MT beep-library.o -MMD -MP -MF .deps/beep-library.o.dep -DPACKAGE_TARNAME='"beep"' -DPACKAGE_VERSION='"1.4.12"' -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral
-fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj -o beep-library.o -c beep-library.c
sed -e 's|@PACKAGE_TARNAME@|beep|g' -e 's|@PACKAGE_VERSION@|1.4.12|g' -e 's|@DEFAULT_FREQ@|440|g' -e 's|@DEFAULT_LENGTH@|200|g' -e 's|@DEFAULT_DELAY@|100|g' -e 's|[@]docdir@|/usr/local/share/doc/beep|g' < beep-usage.txt.in > beep-usage.txt.new
mv -f beep-usage.txt.new beep-usage.txt
x86_64-pc-linux-musl-cc -MT beep-drivers.o -MMD -MP -MF .deps/beep-drivers.o.dep -DPACKAGE_TARNAME='"beep"' -DPACKAGE_VERSION='"1.4.12"' -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral
-fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj -o beep-drivers.o -c beep-drivers.c
x86_64-pc-linux-musl-cc -MT beep-driver-console.o -MMD -MP -MF .deps/beep-driver-console.o.dep -DPACKAGE_TARNAME='"beep"' -DPACKAGE_VERSION='"1.4.12"' -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral -fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj -o beep-driver-console.o -c beep-driver-console.c
x86_64-pc-linux-musl-cc -MT beep-driver-evdev.o -MMD -MP -MF .deps/beep-driver-evdev.o.dep -DPACKAGE_TARNAME='"beep"' -DPACKAGE_VERSION='"1.4.12"' -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral -fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj -o beep-driver-evdev.o -c beep-driver-evdev.c
sed -e 's|@PACKAGE_TARNAME@|beep|g' -e 's|@PACKAGE_VERSION@|1.4.12|g' -e 's|@DEFAULT_FREQ@|440|g' -e 's|@DEFAULT_LENGTH@|200|g' -e 's|@DEFAULT_DELAY@|100|g' -e 's|[@]docdir@|/usr/local/share/doc/beep|g' < beep.1.in > beep.1.new
mv -f beep.1.new beep.1
x86_64-pc-linux-musl-cc -MT beep-log.o -MMD -MP -MF .deps/beep-log.o.dep -DPACKAGE_TARNAME='"beep"' -DPACKAGE_VERSION='"1.4.12"' -D_GNU_SOURCE -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral -fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj -o beep-log.o -c beep-log.c
x86_64-pc-linux-musl-cc -MT beep-main.o -MMD -MP -MF .deps/beep-main.o.dep -DPACKAGE_TARNAME='"beep"' -DPACKAGE_VERSION='"1.4.12"' -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral -fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj -o beep-main.o -c beep-main.c
echo '/* Auto-generated from `beep-usage.txt`. Modify that file instead. */' > beep-usage.c
echo '#include "beep-usage.h"' >> beep-usage.c
echo 'char beep_usage[] =' >> beep-usage.c
set -e; IFS=""; while read line; do \
        printf '  "%s\\n"\n' "${line}" >> beep-usage.c; \
done < beep-usage.txt
echo '  ;' >> beep-usage.c
x86_64-pc-linux-musl-cc -MT beep-usage.o -MMD -MP -MF .deps/beep-usage.o.dep -DPACKAGE_TARNAME='"beep"' -DPACKAGE_VERSION='"1.4.12"' -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral -fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj -o beep-usage.o -c beep-usage.c
x86_64-pc-linux-musl-cc -Wl,-Map=beep.map,--cref -fasynchronous-unwind-tables -fanalyzer -fstack-protector-strong -fstack-clash-protection -fcf-protection -fsanitize=undefined -save-temps=obj -O2 -g -std=gnu99 -pedantic -Wall -Wextra -Werror -Wno-padded -Wno-format-nonliteral   -o beep beep-log.o beep-main.o beep-library.o beep-usage.o beep-drivers.o beep-driver-console.o beep-driver-evdev.o
/usr/x86_64-pc-linux-musl/bin/x86_64-pc-linux-musl-ld: cannot find -lubsan
collect2: error: ld returned 1 exit status
make: *** [GNUmakefile:273: beep] Error 1

!!! ERROR in media-sound/beep-1.4.12::media-unofficial:
!!! In /usr/x86_64-pc-linux-musl/libexec/paludis/utils/exheres-0/emake at line 30
!!! emake returned error 2

!!! Call stack:
!!!    * paludis_die_or_error_func (/usr/x86_64-pc-linux-musl/libexec/paludis/die_functions.bash:82)
!!!    * main (/usr/x86_64-pc-linux-musl/libexec/paludis/utils/exheres-0/emake:30)

diefunc: making ebuild PID 4954 exit with error
die trap: exiting with error.
```

How is `-lubsan` acquired?